### PR TITLE
clean up clang static analysis warnings

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_object.h
+++ b/modules/AIM/module/inc/AIM/aim_object.h
@@ -89,12 +89,10 @@ typedef void (*aim_object_dtor)(aim_object_t*);
 #define AIM_OBJECT_INIT(_object, _id, _subtype, _cookie, _dtor) \
     do {                                                        \
         aim_object_t* _op_ = (aim_object_t*)(_object);          \
-        if(_op_) {                                              \
-            _op_->id = _id;                                     \
-            _op_->subtype = _subtype;                           \
-            _op_->cookie = _cookie;                             \
-            _op_->destructor = _dtor;                           \
-        }                                                       \
+        _op_->id = _id;                                         \
+        _op_->subtype = _subtype;                               \
+        _op_->cookie = _cookie;                                 \
+        _op_->destructor = _dtor;                               \
     } while(0)
 
 

--- a/modules/AIM/module/src/aim_printf.c
+++ b/modules/AIM/module/src/aim_printf.c
@@ -187,7 +187,6 @@ aim_vprintf(aim_pvs_t* pvs, const char* fmt, va_list _vargs)
     int count = 0;
     aim_va_list_t vargs;
 
-    dst = fmt_;
     va_copy(vargs.val, _vargs);
 
 #define NEXT_TOKEN()                            \

--- a/modules/AIM/module/src/aim_string.c
+++ b/modules/AIM/module/src/aim_string.c
@@ -232,8 +232,7 @@ aim_bytes_to_string(uint8_t* data, int size, int columns)
             sp += c, len -= c;
         }
         if((size > columns) && (size % columns != 0)) {
-            c = AIM_SNPRINTF(sp, len, "\n");
-            sp += c, len -= c;
+            AIM_SNPRINTF(sp, len, "\n");
         }
         return s;
     }


### PR DESCRIPTION
Reviewer: trivial

These were mosly just dead code. AIM_OBJECT_INIT had an unnecessary check of 
whether the object was NULL, which caused clang to think that the object could 
possibly be NULL, which resulted in a couple of spurious warnings in the 
callers.
