### PR TITLE
AIM: add a debug-only assert macro

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_utils.h
+++ b/modules/AIM/module/inc/AIM/aim_utils.h
@@ -200,6 +200,22 @@ extern int aim_modules_init(void);
         }                                                               \
     } while(0)
 
+/**
+ * Expression true log and assert.
+ *
+ * Only enabled on debug builds.
+ */
+#ifndef NDEBUG
+#define AIM_ASSERT(_expr, ...)                                             \
+    do {                                                                   \
+        if (!(_expr)) {                                                    \
+            AIM_DIE("debug assertion failed: '" #_expr "': " __VA_ARGS__); \
+        }                                                                  \
+    } while(0)
+#else
+#define AIM_ASSERT(_expr, ...)
+#endif
+
 
 /**
  * Min/Max


### PR DESCRIPTION
Reviewer: @jnealtowns

I want to be able to compile out some assertions on release builds of IVS. I'm
also going to replace INDIGO_ASSERT with this.
