### PR TITLE
builder: allow overriding compiler with CC

### DIFF
--- a/builder/unix/toolchains/gcc-local/obj.mk
+++ b/builder/unix/toolchains/gcc-local/obj.mk
@@ -30,7 +30,10 @@ MAKE_DIR=$(OBJECT_DIR)/$($(TARGET)_SUBDIR)
 include $(BUILDER)/makedir.mk
 
 ifndef GCC
-GCC := gcc
+ifndef CC
+CC := gcc
+endif
+GCC := $(CC)
 endif
 
 CINFO="["


### PR DESCRIPTION
Reviewer: @jnealtowns

clang-analyzer sets the CC environment variable to a wrapper script before 
running make. We already supported the GCC variable, so this change first
looks for GCC and if that's unset uses CC.
