### PR TITLE
Support string format and duplication using AIM datatype formatting.

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_string.h
+++ b/modules/AIM/module/inc/AIM/aim_string.h
@@ -90,6 +90,19 @@ char* aim_fstrdup(const char* fmt, ...);
 char* aim_vfstrdup(const char* fmt, va_list vargs);
 
 /**
+ * @brief Duplicate a string with AIM datatype formatting.
+ * @param fmt The format
+ */
+char* aim_dfstrdup(const char* fmt, ...);
+
+/**
+ * @brief Duplicate a string with AIM datatype formatting.
+ * @param fmt The format.
+ * @param vargs The args.
+ */
+char* aim_vdfstrdup(const char* fmt, va_list vargs);
+
+/**
  * @brief Portable strlcpy
  * @param dst Destination
  * @param src Source

--- a/modules/AIM/module/src/aim_string.c
+++ b/modules/AIM/module/src/aim_string.c
@@ -120,6 +120,28 @@ aim_vfstrdup(const char* fmt, va_list vargs)
     return aim_strdup(b);
 }
 
+char*
+aim_vdfstrdup(const char* fmt, va_list vargs)
+{
+    char* rv;
+    aim_pvs_t* dstpvs = aim_pvs_buffer_create();
+    aim_vprintf(dstpvs, fmt, vargs);
+    rv = aim_pvs_buffer_get(dstpvs);
+    aim_pvs_destroy(dstpvs);
+    return rv;
+}
+
+char*
+aim_dfstrdup(const char* fmt, ...)
+{
+    char* rv;
+    va_list vargs;
+    va_start(vargs, fmt);
+    rv = aim_vdfstrdup(fmt, vargs);
+    va_end(vargs);
+    return rv;
+}
+
 int
 aim_strlcpy(char* dst, const char* src, int size)
 {

--- a/modules/AIM/utest/main.c
+++ b/modules/AIM/utest/main.c
@@ -181,5 +181,11 @@ int aim_main(int argc, char* argv[])
        assert(aim_log2_u32(4294967295) == 31);
     }
 
+    /* Test aim_dfstrdup() */
+    {
+        char* rv = aim_dfstrdup("%d %{bool} %{bool} %d", 1, 1, 0, 0);
+        assert(!strcmp(rv, "1 True False 0"));
+        aim_free(rv);
+    }
     return 0;
 }


### PR DESCRIPTION
Reviewer: @poolakiran 

The existing function aim_fstrdup() is convenient, but does not allow
for AIM custom datatypes in the format string.

The new functions aim_dfstrdup() and aim_vdfstrdup() allow for
AIM datatype formatting in the input.
