### PR TITLE
modify log time format

### DIFF
--- a/modules/AIM/module/src/aim_log.c
+++ b/modules/AIM/module/src/aim_log.c
@@ -501,8 +501,8 @@ aim_log_time__(aim_pvs_t* pvs)
 
     gettimeofday(&timeval, NULL);
     loctime = localtime(&timeval.tv_sec);
-    strftime(lt, sizeof(lt), "%b %d %T", loctime);
-    aim_printf(pvs, "%s.%.03d ", lt, (int)timeval.tv_usec/1000);
+    strftime(lt, sizeof(lt), "%m-%d %T", loctime);
+    aim_printf(pvs, "%s.%.06d ", lt, (int)timeval.tv_usec);
 #else
     AIM_REFERENCE(pvs);
     AIM_REFERENCE(size);


### PR DESCRIPTION
Reviewer: @jnealtowns

I'm working on a tool to merge logfiles from a bunch of IVS switches run under 
mininet. Using microseconds instead of milliseconds improves the quality of
the merged logfile by reducing the amount of reordering. For example, if
switch A sends a packet to switch B and gets a reply back within the same
millisecond, the log may show A getting the reply before B sends it.

Changing the month name to a number lets me merge without parsing the date. If 
using the month name is some kind of standard and changing it would cause 
issues then I'm fine with reverting this part.
