### PR TITLE
AIM: add wrappers for __attribute__

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_compiler.h
+++ b/modules/AIM/module/inc/AIM/aim_compiler.h
@@ -1,0 +1,102 @@
+/****************************************************************
+ *
+ *        Copyright 2014, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+/**************************************************************************//**
+ *
+ *  /module/inc/AIM/aim_compiler.h
+ *
+ * @file
+ * @brief Macros wrapping compiler-specific functionality
+ *
+ * @addtogroup aim-compiler
+ * @{
+ *
+ *****************************************************************************/
+#ifndef __AIM_COMPILER_H__
+#define __AIM_COMPILER_H__
+
+#include <AIM/aim_config.h>
+
+/* Promise GCC that the returned pointer will not alias any other pointer */
+#ifdef __GNUC__
+#define AIM_COMPILER_ATTR_MALLOC __attribute__((__malloc__))
+#else
+/* No-op default implementation */
+#define AIM_COMPILER_ATTR_MALLOC
+#endif
+
+/* Promise GCC that the function will not return */
+#ifdef __GNUC__
+#define AIM_COMPILER_ATTR_NORETURN __attribute__((__noreturn__))
+#else
+/* No-op default implementation */
+#define AIM_COMPILER_ATTR_NORETURN
+#endif
+
+/* This variable may be unused */
+#ifdef __GNUC__
+#define AIM_COMPILER_ATTR_UNUSED __attribute__((__unused__))
+#else
+/* No-op default implementation */
+#define AIM_COMPILER_ATTR_UNUSED
+#endif
+
+/* Don't inline this function */
+#ifdef __GNUC__
+#define AIM_COMPILER_ATTR_NOINLINE __attribute__((__noinline__))
+#else
+/* No-op default implementation */
+#define AIM_COMPILER_ATTR_NOINLINE
+#endif
+
+/* Warn if the result of this function is unused */
+#ifdef __GNUC__
+#define AIM_COMPILER_ATTR_WARN_UNUSED_RESULT __attribute__((__warn_unused_result__))
+#else
+/* No-op default implementation */
+#define AIM_COMPILER_ATTR_WARN_UNUSED_RESULT
+#endif
+
+/*
+ * These attributes don't allow for a no-op fallback. Leave them undefined to
+ * create an error if used and allow users to check if they're available.
+ */
+
+/* Tightly pack a struct */
+#ifdef __GNUC__
+#define AIM_COMPILER_ATTR_PACKED __attribute__((__packed__))
+#endif
+
+/* A pointer to this type may alias pointers to other types */
+#ifdef __GNUC__
+#define AIM_COMPILER_ATTR_MAY_ALIAS __attribute__((__may_alias__))
+#endif
+
+/* This symbol may be overridden by a non-weak symbol from another compilation unit */
+#ifdef __GNUC__
+#define AIM_COMPILER_ATTR_WEAK __attribute__((__weak__))
+#endif
+
+/* Force alignment to N bytes */
+#ifdef __GNUC__
+#define AIM_COMPILER_ATTR_ALIGNED __attribute__((__aligned__ (N)))
+#endif
+
+#endif /* __AIM_COMPILER_H__ */
+/*@}*/

--- a/modules/AIM/module/inc/AIM/aim_error.h
+++ b/modules/AIM/module/inc/AIM/aim_error.h
@@ -28,12 +28,7 @@
 
 #include <AIM/aim_config.h>
 #include <AIM/aim_valist.h>
-
-#ifdef __GNUC__
-#define NORETURN_ATTR __attribute__((__noreturn__))
-#else
-#define NORETURN_ATTR
-#endif
+#include <AIM/aim_compiler.h>
 
 /* <auto.start.enum(aim_error).header> */
 /** aim_error */
@@ -76,12 +71,10 @@ extern aim_map_si_t aim_error_desc_map[];
 void aim_die(const char* function,
              const char* file,
              int line,
-             const char* fmt, ...) NORETURN_ATTR;
+             const char* fmt, ...) AIM_COMPILER_ATTR_NORETURN;
 
 /** This macro should usually be used */
 #define AIM_DIE(...)                                            \
     aim_die(__func__, __FILE__, __LINE__,  __VA_ARGS__ );
-
-#undef NORETURN_ATTR
 
 #endif /* __AIM_ERROR_H__ */

--- a/modules/AIM/module/inc/AIM/aim_memory.h
+++ b/modules/AIM/module/inc/AIM/aim_memory.h
@@ -32,13 +32,7 @@
 #define __AIM_MEMORY_H__
 
 #include <AIM/aim_config.h>
-
-/* Promise GCC that the returned pointer will not alias any other pointer */
-#ifdef __GNUC__
-#define MALLOC_ATTR __attribute__((__malloc__))
-#else
-#define MALLOC_ATTR
-#endif
+#include <AIM/aim_compiler.h>
 
 /**
  * @brief Allocate memory.
@@ -47,7 +41,7 @@
  * The returned memory is uninitialized.
  * Aborts if allocation fails.
  */
-void *aim_malloc(size_t size) MALLOC_ATTR;
+void *aim_malloc(size_t size) AIM_COMPILER_ATTR_MALLOC;
 
 /**
  * @brief Zero'ed memory alloc.
@@ -55,7 +49,7 @@ void *aim_malloc(size_t size) MALLOC_ATTR;
  *
  * Aborts if allocation fails.
  */
-void *aim_zmalloc(size_t size) MALLOC_ATTR;
+void *aim_zmalloc(size_t size) AIM_COMPILER_ATTR_MALLOC;
 
 /**
  * @brief Resize memory.
@@ -84,7 +78,7 @@ void aim_free(void *data);
  *
  * Aborts if allocation fails.
  */
-void *aim_memdup(void *src, size_t size) MALLOC_ATTR;
+void *aim_memdup(void *src, size_t size) AIM_COMPILER_ATTR_MALLOC;
 
 /**
  * @brief Duplicate memory.
@@ -94,9 +88,7 @@ void *aim_memdup(void *src, size_t size) MALLOC_ATTR;
  *
  * Aborts if allocation fails.
  */
-void *aim_memndup(void *src, size_t src_size, size_t alloc_size) MALLOC_ATTR;
-
-#undef MALLOC_ATTR
+void *aim_memndup(void *src, size_t src_size, size_t alloc_size) AIM_COMPILER_ATTR_MALLOC;
 
 #endif /* __AIM_MEMORY_H__ */
 /*@}*/


### PR DESCRIPTION
Reviewer: @jnealtowns

We use all of these attributes and they're usually accompanied by "#ifdef
**GNUC**". Adding wrappers to AIM makes using them less painful.
