### PR TITLE
AIM: squelch unused variable warnings from ASSERT

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_utils.h
+++ b/modules/AIM/module/inc/AIM/aim_utils.h
@@ -213,7 +213,7 @@ extern int aim_modules_init(void);
         }                                                                  \
     } while(0)
 #else
-#define AIM_ASSERT(_expr, ...)
+#define AIM_ASSERT(_expr, ...) AIM_REFERENCE(sizeof(_expr))
 #endif
 
 


### PR DESCRIPTION
Reviewer: @jnealtowns

We occasionally need to define variables solely for the purpose of asserting
on them. These assertions are compiled out on release builds, so the compiler
will warn that these variables are unused.

Using AIM_REFERENCE in the release assert macro mostly solves the problem, but 
there's a chance that the assertion is actually a function call that the 
compiler might not be able to optimize away. Using sizeof ensures the compiler 
won't generate any code on a release build.
