### PR TITLE
Introduce the DEPENDMODULE_HEADERS variable.

### DIFF
--- a/builder/unix/dependmodules.mk
+++ b/builder/unix/dependmodules.mk
@@ -1,13 +1,13 @@
 ################################################################
 #
-#        Copyright 2013, Big Switch Networks, Inc. 
-# 
+#        Copyright 2013, Big Switch Networks, Inc.
+#
 # Licensed under the Eclipse Public License, Version 1.0 (the
 # "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
-# 
+#
 #        http://www.eclipse.org/legal/epl-v10.html
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
@@ -69,6 +69,7 @@ include $(foreach mod,$(DEPENDMODULES),$($(mod)_BASEDIR)/$(mod).mk)
 #
 # $GLOBAL_INCLUDES is referenced by the toolchain directly
 GLOBAL_INCLUDES += $(foreach mod,$(DEPENDMODULES), $($(mod)_INCLUDES))
+GLOBAL_INCLUDES += $(foreach mod,$(DEPENDMODULE_HEADERS),-I$($(mod)_BASEDIR)/module/inc)
 
 #
 # Add all $(MODULE)_GLOBAL_LINK_LIBS to $(GLOBAL_LINK_LIBS)


### PR DESCRIPTION
Reviewer: @jnealtowns

Modules that require the public headers of another module in order to compile
but don't want to compile that module itself can now add those modules to
the DEPENDMODULE_HEADERS variable.

The current version is not entirely correct as it grabs the $(mod)/module/inc
directory directly when it should probably honor the $(mod)_INCLUDES variable
exported by the module's own makefiles. That setting would have to be
teased out of the makefile structure first.
