### PR TITLE
Push log flag downwards, so that syslog severity can be derived from it.

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_log.h
+++ b/modules/AIM/module/inc/AIM/aim_log.h
@@ -44,42 +44,7 @@
  *
  *****************************************************************************/
 
-/* <auto.start.enum(aim_log_flag).header> */
-/** aim_log_flag */
-typedef enum aim_log_flag_e {
-    AIM_LOG_FLAG_MSG,
-    AIM_LOG_FLAG_FATAL,
-    AIM_LOG_FLAG_ERROR,
-    AIM_LOG_FLAG_WARN,
-    AIM_LOG_FLAG_INFO,
-    AIM_LOG_FLAG_VERBOSE,
-    AIM_LOG_FLAG_TRACE,
-    AIM_LOG_FLAG_INTERNAL,
-    AIM_LOG_FLAG_BUG,
-    AIM_LOG_FLAG_FTRACE,
-} aim_log_flag_t;
-
-/** Enum names. */
-const char* aim_log_flag_name(aim_log_flag_t e);
-
-/** Enum values. */
-int aim_log_flag_value(const char* str, aim_log_flag_t* e, int substr);
-
-/** Enum descriptions. */
-const char* aim_log_flag_desc(aim_log_flag_t e);
-
-/** Enum validator. */
-int aim_log_flag_valid(aim_log_flag_t e);
-
-/** validator */
-#define AIM_LOG_FLAG_VALID(_e) \
-    (aim_log_flag_valid((_e)))
-
-/** aim_log_flag_map table. */
-extern aim_map_si_t aim_log_flag_map[];
-/** aim_log_flag_desc_map table. */
-extern aim_map_si_t aim_log_flag_desc_map[];
-/* <auto.end.enum(aim_log_flag).header> */
+#include <AIM/aim_log_flag.h>
 
 /* <auto.start.enum(aim_log_bit).header> */
 /** aim_log_bit */

--- a/modules/AIM/module/inc/AIM/aim_log_flag.h
+++ b/modules/AIM/module/inc/AIM/aim_log_flag.h
@@ -1,0 +1,74 @@
+/****************************************************************
+ *
+ *        Copyright 2014, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+/**************************************************************************//**
+ *
+ * @file
+ * @brief AIM Log Flag
+ *
+ *
+ * @addtogroup aim-log
+ * @{
+ *
+ *****************************************************************************/
+#ifndef __AIM_LOG_FLAG_H__
+#define __AIM_LOG_FLAG_H__
+
+#include <AIM/aim_map.h>
+
+/* <auto.start.enum(aim_log_flag).header> */
+/** aim_log_flag */
+typedef enum aim_log_flag_e {
+    AIM_LOG_FLAG_MSG,
+    AIM_LOG_FLAG_FATAL,
+    AIM_LOG_FLAG_ERROR,
+    AIM_LOG_FLAG_WARN,
+    AIM_LOG_FLAG_INFO,
+    AIM_LOG_FLAG_VERBOSE,
+    AIM_LOG_FLAG_TRACE,
+    AIM_LOG_FLAG_INTERNAL,
+    AIM_LOG_FLAG_BUG,
+    AIM_LOG_FLAG_FTRACE,
+} aim_log_flag_t;
+
+/** Enum names. */
+const char* aim_log_flag_name(aim_log_flag_t e);
+
+/** Enum values. */
+int aim_log_flag_value(const char* str, aim_log_flag_t* e, int substr);
+
+/** Enum descriptions. */
+const char* aim_log_flag_desc(aim_log_flag_t e);
+
+/** Enum validator. */
+int aim_log_flag_valid(aim_log_flag_t e);
+
+/** validator */
+#define AIM_LOG_FLAG_VALID(_e) \
+    (aim_log_flag_valid((_e)))
+
+/** aim_log_flag_map table. */
+extern aim_map_si_t aim_log_flag_map[];
+/** aim_log_flag_desc_map table. */
+extern aim_map_si_t aim_log_flag_desc_map[];
+
+/* <auto.end.enum(aim_log_flag).header> */
+
+#endif /* __AIM_LOG_FLAG_H__ */
+/* @}*/

--- a/modules/AIM/module/inc/AIM/aim_pvs.h
+++ b/modules/AIM/module/inc/AIM/aim_pvs.h
@@ -35,6 +35,7 @@
 #include <AIM/aim_config.h>
 #include <AIM/aim_valist.h>
 #include <AIM/aim_object.h>
+#include <AIM/aim_log_flag.h>
 #include <stdarg.h>
 
 /** aim_pvs_t */
@@ -43,7 +44,8 @@ typedef struct aim_pvs_s aim_pvs_t;
 /**
  * All fundamental output vectors share this signature.
  */
-typedef int (*aim_vprint_f)(aim_pvs_t* pvs, const char* fmt, va_list vargs);
+typedef int (*aim_vprint_f)(aim_pvs_t* pvs, aim_log_flag_t flag,
+                            const char* fmt, va_list vargs);
 
 
 /**
@@ -98,31 +100,36 @@ extern aim_pvs_t aim_pvs_none;
 /**
  * @brief printf-style output to any PVS.
  * @param pvs The PVS output stream.
+ * @param flag The associated AIM log flag.
  * @param fmt The format string.
  * @note This does not include custom datatype processing.
  * @note Most clients should call aim_printf() instead.
  */
-int aim_pvs_printf(aim_pvs_t* pvs, const char* fmt, ...);
+int aim_pvs_printf(aim_pvs_t* pvs, aim_log_flag_t flag, const char* fmt, ...);
 
 /**
  * @brief vprintf-style output to any PVS.
  * @param pvs The PVS output stream.
+ * @param flag The associated AIM log flag.
  * @param fmt The format string.
  * @param vargs The format arguments.
  * @note This does not include custom datatype processing.
  * @note Most clients should call aim_vprintf() instead.
  */
-int aim_pvs_vprintf(aim_pvs_t* pvs, const char* fmt, va_list vargs);
+int aim_pvs_vprintf(aim_pvs_t* pvs, aim_log_flag_t flag,
+                    const char* fmt, va_list vargs);
 
 /**
  * @brief vprintf-style output to any PVS.
  * @param pvs The PVS output stream.
+ * @param flag The associated AIM log flag.
  * @param fmt The format string.
  * @param vargs The AIM variable argument structure.
  * @note This does not include custom datatype processing.
  * @note Most clients should call aim_avprintf() instead.
  */
-int aim_pvs_avprintf(aim_pvs_t* pvs, const char* fmt, aim_va_list_t* vargs);
+int aim_pvs_avprintf(aim_pvs_t* pvs, aim_log_flag_t flag,
+                     const char* fmt, aim_va_list_t* vargs);
 
 /**
  * @brief Enable or disable output on the given PVS.

--- a/modules/AIM/module/src/aim_datatypes.c
+++ b/modules/AIM/module/src/aim_datatypes.c
@@ -181,12 +181,13 @@ aim_datatype_fs__rmap__(aim_datatype_context_t* dtc, const char* arg,
     }
 
     /* fixme */
-    aim_pvs_printf(dtc->epvs,
+    aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG,
                    "%s is not a valid %s. Choices are: ", arg, dtc->dt->desc);
     for(p = map; p->s; p++) {
-        aim_pvs_printf(dtc->epvs, "%s%s ", p->s, (p+1)->s ? "," : "");
+        aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG,
+                       "%s%s ", p->s, (p+1)->s ? "," : "");
     }
-    aim_pvs_printf(dtc->epvs, "\n");
+    aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG, "\n");
     return -1;
 }
 
@@ -364,11 +365,13 @@ aim_datatype_fs__rint__(aim_datatype_context_t* dtc, const char* arg,
     char* desc = va_arg(vargs->val, char*);
 
     if(aim_datatype_fs_int(arg, rv) != 0) {
-        aim_pvs_printf(dtc->epvs, "%s is not an integer.\n", arg);
+        aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG,
+                       "%s is not an integer.\n", arg);
         return AIM_STATUS_E_ARG;
     }
     if(*rv < low || *rv > high) {
-        aim_pvs_printf(dtc->epvs, "value %d [for argument %s] must be between %d and %d.\n",
+        aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG,
+                       "value %d [for argument %s] must be between %d and %d.\n",
                        *rv, desc, low, high);
         return AIM_STATUS_E_ARG;
     }
@@ -403,7 +406,7 @@ aim_datatype_fs__idata__(aim_datatype_context_t* dtc, const char* arg,
     int      _size;
     _data = aim_bytes_from_string(arg, &_size);
     if(_size > *size) {
-        aim_pvs_printf(dtc->epvs, "too much data.\n");
+        aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG, "too much data.\n");
     }
     AIM_MEMCPY(data, _data, _size);
     *size = _size;
@@ -450,11 +453,13 @@ aim_datatype_fs__map__(aim_datatype_context_t* dtc, const char* arg,
             return AIM_STATUS_OK;
         }
     }
-    aim_pvs_printf(dtc->epvs, "%s is not a valid %s. Choices are: ", arg, desc);
+    aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG,
+                   "%s is not a valid %s. Choices are: ", arg, desc);
     for(p = map; p->s; p++) {
-        aim_pvs_printf(dtc->epvs, "%s%s ", p->s, (p+1)->s ? "," : "");
+        aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG,
+                       "%s%s ", p->s, (p+1)->s ? "," : "");
     }
-    aim_pvs_printf(dtc->epvs, "\n");
+    aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG, "\n");
     return AIM_STATUS_E_ARG;
 }
 
@@ -488,11 +493,13 @@ aim_datatype_fs__choice__(aim_datatype_context_t* dtc, const char* arg,
         }
     }
     if(*rv == -1) {
-        aim_pvs_printf(dtc->epvs, "%s is not a valid %s. Choices are: ", arg, desc);
+        aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG,
+                       "%s is not a valid %s. Choices are: ", arg, desc);
         for(i = 0; i < count; i++) {
-            aim_pvs_printf(dtc->epvs, "%s%s ", choices[i], i != (count-1) ? "," : "");
+            aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG,
+                           "%s%s ", choices[i], i != (count-1) ? "," : "");
         }
-        aim_pvs_printf(dtc->epvs, "\n");
+        aim_pvs_printf(dtc->epvs, AIM_LOG_FLAG_MSG, "\n");
         aim_free(choices);
         return AIM_STATUS_E_ARG;
     }
@@ -683,7 +690,7 @@ aim_datatype_ts__aim_bitmap__(aim_datatype_context_t* dtc, aim_va_list_t* vargs,
         int bit;
 
         AIM_BITMAP_ITER(bmap, bit) {
-            aim_pvs_printf(pvsb, "%d ", bit);
+            aim_pvs_printf(pvsb, AIM_LOG_FLAG_MSG, "%d ", bit);
         }
 
         *rv = aim_pvs_buffer_get(pvsb);

--- a/modules/AIM/module/src/aim_error.c
+++ b/modules/AIM/module/src/aim_error.c
@@ -43,8 +43,8 @@ void aim_die(const char* function,
                     function, file, line,
                     fmt, va);
 
-    aim_pvs_vprintf(&aim_pvs_stderr, fmt, vb);
-    aim_pvs_printf(&aim_pvs_stderr, "\n");
+    aim_pvs_vprintf(&aim_pvs_stderr, AIM_LOG_FLAG_FATAL, fmt, vb);
+    aim_pvs_printf(&aim_pvs_stderr, AIM_LOG_FLAG_FATAL, "\n");
     /* Fixme/Todo */
     abort();
 }

--- a/modules/AIM/module/src/aim_log.c
+++ b/modules/AIM/module/src/aim_log.c
@@ -513,7 +513,8 @@ aim_log_time__(aim_pvs_t* pvs)
  * Basic output function for all log messages.
  */
 static void
-aim_log_output__(aim_log_t* l, const char* fname, const char* file,
+aim_log_output__(aim_log_t* l, aim_log_flag_t flag, 
+                 const char* fname, const char* file,
                  int line, const char* fmt, va_list vargs)
 {
     aim_pvs_t* msg;
@@ -532,7 +533,7 @@ aim_log_output__(aim_log_t* l, const char* fname, const char* file,
     }
     aim_printf(msg, "\n");
     pmsg = aim_pvs_buffer_get(msg);
-    aim_printf(l->pvs, "%s", pmsg);
+    aim_pvs_printf(l->pvs, flag, "%s", pmsg);
     aim_free(pmsg);
     aim_pvs_destroy(msg);
 }
@@ -637,7 +638,7 @@ aim_log_vcommon(aim_log_t* l, aim_log_flag_t flag,
                 }
             }
 
-            aim_log_output__(l, fname, file, line, fmt, vargs);
+            aim_log_output__(l, flag, fname, file, line, fmt, vargs);
 
             if(color) {
                 aim_printf(l->pvs, color_reset__);
@@ -667,7 +668,8 @@ aim_log_vcustom(aim_log_t* l, int fid,
 {
     if(aim_log_custom_enabled(l, fid)) {
         if(rl == NULL || aim_ratelimiter_limit(rl, time) == 0) {
-            aim_log_output__(l, fname, file, line, fmt, vargs);
+            aim_log_output__(l, AIM_LOG_FLAG_INFO,
+                             fname, file, line, fmt, vargs);
         }
     }
 }

--- a/modules/AIM/module/src/aim_printf.c
+++ b/modules/AIM/module/src/aim_printf.c
@@ -216,7 +216,8 @@ aim_vprintf(aim_pvs_t* pvs, const char* fmt, va_list _vargs)
                 }
                 if(*src == 0) {
                     /* Malformed */
-                    count += aim_pvs_printf(pvs, fmt_, "%BADFORMAT");
+                    count += aim_pvs_printf(pvs, AIM_LOG_FLAG_MSG,
+                                            fmt_, "%BADFORMAT");
                     aim_free(fmt_);
                     return count;
                 }
@@ -224,7 +225,8 @@ aim_vprintf(aim_pvs_t* pvs, const char* fmt, va_list _vargs)
                     aim_datatype_t* dt = aim_datatype_find(0, type);
                     if(dt == NULL) {
                         /* bad or missing type */
-                        count += aim_pvs_printf(pvs, "{error:unknown type %s}", type);
+                        count += aim_pvs_printf(pvs, AIM_LOG_FLAG_MSG,
+                                                "{error:unknown type %s}", type);
                         /*
                          * Its hard to continue from here. We don't know
                          * the number and type of arguments that were passed
@@ -241,7 +243,8 @@ aim_vprintf(aim_pvs_t* pvs, const char* fmt, va_list _vargs)
                         dtc.dt = dt;
                         dtc.epvs = pvs;
                         dt->to_str(&dtc, &vargs, &rv);
-                        count += aim_pvs_printf(pvs, fmt_, rv);
+                        count += aim_pvs_printf(pvs, AIM_LOG_FLAG_MSG,
+                                                fmt_, rv);
                         aim_free((char*)rv);
                     }
                 }
@@ -257,7 +260,7 @@ aim_vprintf(aim_pvs_t* pvs, const char* fmt, va_list _vargs)
                 *dst=0;
 
                 va_copy(vac, vargs.val);
-                count += aim_pvs_vprintf(pvs, fmt_, vac);
+                count += aim_pvs_vprintf(pvs, AIM_LOG_FLAG_MSG, fmt_, vac);
                 va_end(vac);
                 pull_format_argument__(fmt_, &vargs);
             }
@@ -266,7 +269,7 @@ aim_vprintf(aim_pvs_t* pvs, const char* fmt, va_list _vargs)
         src++;
     }
     if(dst != fmt_) {
-        count += aim_pvs_vprintf(pvs, fmt_, vargs.val);
+        count += aim_pvs_vprintf(pvs, AIM_LOG_FLAG_MSG, fmt_, vargs.val);
     }
     aim_free(fmt_);
     return count;

--- a/modules/AIM/module/src/aim_pvs.c
+++ b/modules/AIM/module/src/aim_pvs.c
@@ -30,7 +30,8 @@
 #include <stdio.h>
 
 int
-aim_pvs_avprintf(aim_pvs_t* pvs, const char* fmt, aim_va_list_t* vargs)
+aim_pvs_avprintf(aim_pvs_t* pvs, aim_log_flag_t flag,
+                 const char* fmt, aim_va_list_t* vargs)
 {
     if(pvs == NULL) {
         return 0;
@@ -39,11 +40,13 @@ aim_pvs_avprintf(aim_pvs_t* pvs, const char* fmt, aim_va_list_t* vargs)
     if(pvs->enabled == 0) {
         return 0;
     }
-    return pvs->vprintf(pvs, fmt, vargs->val);
+
+    return pvs->vprintf(pvs, flag, fmt, vargs->val);
 }
 
 int
-aim_pvs_vprintf(aim_pvs_t* pvs, const char* fmt, va_list vargs)
+aim_pvs_vprintf(aim_pvs_t* pvs, aim_log_flag_t flag,
+                const char* fmt, va_list vargs)
 {
     if(pvs == NULL) {
         return 0;
@@ -52,16 +55,17 @@ aim_pvs_vprintf(aim_pvs_t* pvs, const char* fmt, va_list vargs)
     if(pvs->enabled == 0) {
         return 0;
     }
-    return pvs->vprintf(pvs, fmt, vargs);
+
+    return pvs->vprintf(pvs, flag, fmt, vargs);
 }
 
 int
-aim_pvs_printf(aim_pvs_t* pvs, const char* fmt, ...)
+aim_pvs_printf(aim_pvs_t* pvs, aim_log_flag_t flag, const char* fmt, ...)
 {
     int rv;
     va_list vargs;
     va_start(vargs, fmt);
-    rv = aim_pvs_vprintf(pvs, fmt, vargs);
+    rv = aim_pvs_vprintf(pvs, flag, fmt, vargs);
     va_end(vargs);
     return rv;
 }

--- a/modules/AIM/module/src/aim_pvs_buffer.c
+++ b/modules/AIM/module/src/aim_pvs_buffer.c
@@ -65,12 +65,14 @@ static void aim_pvs_buffer_destroy__(aim_object_t*);
  * Output buffer function.
  */
 static int
-aim_pvs_buffer_vprintf__(aim_pvs_t* _pvs, const char* fmt, va_list vargs)
+aim_pvs_buffer_vprintf__(aim_pvs_t* _pvs, aim_log_flag_t flag,
+                         const char* fmt, va_list vargs)
 {
     aim_pvs_buffer_t* pvs = (aim_pvs_buffer_t*)_pvs;
     int count;
     char* p;
     va_list vacopy;
+    AIM_REFERENCE(flag);
 
     va_copy(vacopy, vargs);
     count = aim_vsnprintf(NULL, 0, fmt, vacopy);

--- a/modules/AIM/module/src/aim_pvs_file.c
+++ b/modules/AIM/module/src/aim_pvs_file.c
@@ -56,9 +56,11 @@ typedef enum aim_pvs_file_subtypes_e {
  * Output to FILE*
  */
 static int
-aim_vprint_fp__(aim_pvs_t* pvs, const char* fmt, va_list vargs)
+aim_vprint_fp__(aim_pvs_t* pvs, aim_log_flag_t flag,
+                const char* fmt, va_list vargs)
 {
     int rv = 0;
+    AIM_REFERENCE(flag);
 
     /**
      * Special checks for stdout/stderr


### PR DESCRIPTION
Reviewer: @rlane 

i am sure that this is not what you had in mind when we talked about making the log flag available at lower levels.  Please let me know how you would improve it.  If it's not recoverable, i'm happy to start over again.  Thanks.
