### PR TITLE
Add syslog support.

### DIFF
--- a/modules/AIM/module/auto/AIM.yml
+++ b/modules/AIM/module/auto/AIM.yml
@@ -130,6 +130,17 @@ aim_log_bits: &aim_log_bits
 - bug:       (1 << AIM_LOG_FLAG_BUG)
 - ftrace:    (1 << AIM_LOG_FLAG_FTRACE)
 
+aim_syslog_types: &aim_syslog_types
+- emerg
+- alert
+- crit
+- error
+- warn
+- notice
+- info
+- debug
+
+
 definitions:
   cdefs:
     AIM_CONFIG_HEADER:
@@ -166,6 +177,10 @@ definitions:
 
     aim_error:
       members: *aim_error_types
+
+    aim_syslog_flag:
+      members: *aim_syslog_types
+
 
   portingmacro:
     AIM:

--- a/modules/AIM/module/inc/AIM/aim_log.h
+++ b/modules/AIM/module/inc/AIM/aim_log.h
@@ -37,6 +37,7 @@
 #include <AIM/aim_utils.h>
 #include <AIM/aim_log_util.h>
 #include <AIM/aim_pvs_file.h>
+#include <AIM/aim_list.h>
 
 
 /******************************************************************************
@@ -145,6 +146,52 @@ extern aim_map_si_t aim_log_option_bit_map[];
 extern aim_map_si_t aim_log_option_bit_desc_map[];
 /* <auto.end.enum(aim_log_option_bit).header> */
 
+/* <auto.start.enum(aim_syslog_flag).header> */
+/** aim_syslog_flag */
+typedef enum aim_syslog_flag_e {
+    AIM_SYSLOG_FLAG_EMERG,
+    AIM_SYSLOG_FLAG_ALERT,
+    AIM_SYSLOG_FLAG_CRIT,
+    AIM_SYSLOG_FLAG_ERROR,
+    AIM_SYSLOG_FLAG_WARN,
+    AIM_SYSLOG_FLAG_NOTICE,
+    AIM_SYSLOG_FLAG_INFO,
+    AIM_SYSLOG_FLAG_DEBUG,
+    AIM_SYSLOG_FLAG_LAST = AIM_SYSLOG_FLAG_DEBUG,
+    AIM_SYSLOG_FLAG_COUNT,
+    AIM_SYSLOG_FLAG_INVALID = -1,
+} aim_syslog_flag_t;
+
+/** Strings macro. */
+#define AIM_SYSLOG_FLAG_STRINGS \
+{\
+    "emerg", \
+    "alert", \
+    "crit", \
+    "error", \
+    "warn", \
+    "notice", \
+    "info", \
+    "debug", \
+}
+/** Enum names. */
+const char* aim_syslog_flag_name(aim_syslog_flag_t e);
+
+/** Enum values. */
+int aim_syslog_flag_value(const char* str, aim_syslog_flag_t* e, int substr);
+
+/** Enum descriptions. */
+const char* aim_syslog_flag_desc(aim_syslog_flag_t e);
+
+/** validator */
+#define AIM_SYSLOG_FLAG_VALID(_e) \
+    ( (0 <= (_e)) && ((_e) <= AIM_SYSLOG_FLAG_DEBUG))
+
+/** aim_syslog_flag_map table. */
+extern aim_map_si_t aim_syslog_flag_map[];
+/** aim_syslog_flag_desc_map table. */
+extern aim_map_si_t aim_syslog_flag_desc_map[];
+/* <auto.end.enum(aim_syslog_flag).header> */
 
 
 /**************************************************************************//**
@@ -1002,6 +1049,205 @@ extern aim_log_t AIM_LOG_STRUCT;
     AIM_LOG_MOD_RL_COMMON(FTRACE, _rl, _time, "%s:EXIT " AIM_VA_ARGS_FIRST(__VA_ARGS__), __func__ AIM_VA_ARGS_REST(__VA_ARGS__))
 
 #endif /* AIM_LOG_MODULE_NAME */
+
+
+/* Syslog macros */
+#define AIM_SYSLOG_EMERG(_documentation, ...)                           \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_EMERG, NULL, 0,              \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_COMMON(MSG, "EMERG: "                               \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+    } while (0);
+#define AIM_SYSLOG_RL_EMERG(_documentation, _rl, _time, ...)            \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_EMERG, _rl, _time,           \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_RL_COMMON(MSG, _rl, _time, "EMERG: "                \
+                              AIM_VA_ARGS_FIRST(__VA_ARGS__)            \
+                              AIM_VA_ARGS_REST(__VA_ARGS__));           \
+    } while (0);
+
+#define AIM_SYSLOG_ALERT(_documentation, ...)                           \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_ALERT, NULL, 0,              \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_COMMON(MSG, "ALERT: "                               \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+    } while (0);
+#define AIM_SYSLOG_RL_ALERT(_documentation, _rl, _time, ...)            \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_ALERT, _rl, _time,           \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_RL_COMMON(MSG, _rl, _time, "ALERT: "                \
+                              AIM_VA_ARGS_FIRST(__VA_ARGS__)            \
+                              AIM_VA_ARGS_REST(__VA_ARGS__));           \
+    } while (0);
+
+#define AIM_SYSLOG_CRIT(_documentation, ...)                            \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_CRIT, NULL, 0,               \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_COMMON(MSG, "CRIT: "                                \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+    } while (0);
+#define AIM_SYSLOG_RL_CRIT(_documentation, _rl, _time, ...)             \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_CRIT, _rl, _time,            \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_RL_COMMON(MSG, _rl, _time, "CRIT: "                 \
+                              AIM_VA_ARGS_FIRST(__VA_ARGS__)            \
+                              AIM_VA_ARGS_REST(__VA_ARGS__));           \
+    } while (0);
+
+#define AIM_SYSLOG_ERROR(_documentation, ...)                           \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_ERROR, NULL, 0,              \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_COMMON(MSG, "ERROR: "                               \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+    } while (0);
+#define AIM_SYSLOG_RL_ERROR(_documentation, _rl, _time, ...)            \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_ERROR, _rl, _time,           \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_RL_COMMON(MSG, _rl, _time, "ERROR: "                \
+                              AIM_VA_ARGS_FIRST(__VA_ARGS__)            \
+                              AIM_VA_ARGS_REST(__VA_ARGS__));           \
+    } while (0);
+
+#define AIM_SYSLOG_WARN(_documentation, ...)                            \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_WARN, NULL, 0,               \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_COMMON(MSG, "WARN: "                                \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+    } while (0);
+#define AIM_SYSLOG_RL_WARN(_documentation, _rl, _time, ...)             \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_WARN, _rl, _time,            \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_RL_COMMON(MSG, _rl, _time, "WARN: "                 \
+                              AIM_VA_ARGS_FIRST(__VA_ARGS__)            \
+                              AIM_VA_ARGS_REST(__VA_ARGS__));           \
+    } while (0);
+
+#define AIM_SYSLOG_NOTICE(_documentation, ...)                          \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_NOTICE, NULL, 0,             \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_COMMON(MSG, "NOTICE: "                              \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+    } while (0);
+#define AIM_SYSLOG_RL_NOTICE(_documentation, _rl, _time, ...)           \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_NOTICE, _rl, _time,          \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_RL_COMMON(MSG, _rl, _time, "NOTICE: "               \
+                              AIM_VA_ARGS_FIRST(__VA_ARGS__)            \
+                              AIM_VA_ARGS_REST(__VA_ARGS__));           \
+    } while (0);
+
+#define AIM_SYSLOG_INFO(_documentation, ...)                            \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_INFO, NULL, 0,               \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_COMMON(MSG, "INFO: "                                \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+    } while (0);
+#define AIM_SYSLOG_RL_INFO(_documentation, _rl, _time, ...)             \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_INFO, _rl, _time,            \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_RL_COMMON(MSG, _rl, _time, "INFO: "                 \
+                              AIM_VA_ARGS_FIRST(__VA_ARGS__)            \
+                              AIM_VA_ARGS_REST(__VA_ARGS__));           \
+    } while (0);
+
+#define AIM_SYSLOG_DEBUG(...)                                           \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_DEBUG, NULL, 0,              \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_COMMON(MSG, "DEBUG: "                               \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+    } while (0);
+#define AIM_SYSLOG_RL_DEBUG(_rl, _time, ...)                            \
+    do {                                                                \
+        aim_syslogf_invoke(AIM_SYSLOG_FLAG_DEBUG, _rl, _time,           \
+                           AIM_VA_ARGS_FIRST(__VA_ARGS__)               \
+                           AIM_VA_ARGS_REST(__VA_ARGS__));              \
+        AIM_LOG_MOD_RL_COMMON(MSG, _rl, _time, "DEBUG: "                \
+                              AIM_VA_ARGS_FIRST(__VA_ARGS__)            \
+                              AIM_VA_ARGS_REST(__VA_ARGS__));           \
+    } while (0);
+
+
+/**
+ * @brief Log function typedef, to be used by aim_syslogf_register and
+ *   aim_dbglogf_register.
+ * @param cookie To be passed to logging function when it is invoked.
+ * @param flag Log level.
+ * @param str String to log.
+ */
+typedef void (*aim_syslog_f)(void* cookie, aim_syslog_flag_t flag, 
+                             const char* str);
+
+typedef struct aim_syslog_handler_s {
+    aim_syslog_f logf;
+    void *cookie;
+    list_links_t links;
+} aim_syslog_handler_t;
+
+/**
+ * @brief Register a syslog handler.
+ * @param handler The syslog handler block.
+ * @param logf The actual syslog logging function.
+ * @param cookie To be passed to the logging function when invoked.
+ */
+void aim_syslogf_register(aim_syslog_handler_t *handler,
+                          aim_syslog_f logf, void* cookie);
+
+/**
+ * @brief Unregister a syslog handler.
+ * @param handler The syslog handler block.
+ */
+void aim_syslogf_unregister(aim_syslog_handler_t *handler);
+
+/**
+ * @brief Invoke the registered syslog log functions.
+ * @param flag  The syslog level.
+ * @param rl    The aim ratelimiter.
+ * @param time  The current time.
+ * @param fmt   The message format string.
+ * @param vargs The arguments.
+ */
+void aim_syslogf_invoke(aim_syslog_flag_t flag,
+                        aim_ratelimiter_t* rl, uint64_t time,
+                        const char* fmt, ...);
+
 
 /**
  * @brief Map a syslog level string to a set of flags and options

--- a/modules/AIM/module/src/aim_enums.c
+++ b/modules/AIM/module/src/aim_enums.c
@@ -171,6 +171,136 @@ aim_log_option_valid(aim_log_option_t e)
 }
 
 
+aim_map_si_t aim_error_map[] =
+{
+    { "none", AIM_ERROR_NONE },
+    { "param", AIM_ERROR_PARAM },
+    { "not_found", AIM_ERROR_NOT_FOUND },
+    { "internal", AIM_ERROR_INTERNAL },
+    { NULL, 0 }
+};
+
+aim_map_si_t aim_error_desc_map[] =
+{
+    { "No error.", AIM_ERROR_NONE },
+    { "One of the function parameters was invalid.", AIM_ERROR_PARAM },
+    { "The requested object was not found.", AIM_ERROR_NOT_FOUND },
+    { "An unexpected internal error occurred.", AIM_ERROR_INTERNAL },
+    { NULL, 0 }
+};
+
+const char*
+aim_error_name(aim_error_t e)
+{
+    const char* name;
+    if(aim_map_si_i(&name, e, aim_error_map, 0)) {
+        return name;
+    }
+    else {
+        return "-invalid value for enum type 'aim_error'";
+    }
+}
+
+int
+aim_error_value(const char* str, aim_error_t* e, int substr)
+{
+    int i;
+    AIM_REFERENCE(substr);
+    if(aim_map_si_s(&i, str, aim_error_map, 0)) {
+        /* Enum Found */
+        *e = i;
+        return 0;
+    }
+    else {
+        return -1;
+    }
+}
+
+const char*
+aim_error_desc(aim_error_t e)
+{
+    const char* name;
+    if(aim_map_si_i(&name, e, aim_error_desc_map, 0)) {
+        return name;
+    }
+    else {
+        return "-invalid value for enum type 'aim_error'";
+    }
+}
+
+int
+aim_error_valid(aim_error_t e)
+{
+    return aim_map_si_i(NULL, e, aim_error_map, 0) ? 1 : 0;
+}
+
+
+aim_map_si_t aim_syslog_flag_map[] =
+{
+    { "emerg", AIM_SYSLOG_FLAG_EMERG },
+    { "alert", AIM_SYSLOG_FLAG_ALERT },
+    { "crit", AIM_SYSLOG_FLAG_CRIT },
+    { "error", AIM_SYSLOG_FLAG_ERROR },
+    { "warn", AIM_SYSLOG_FLAG_WARN },
+    { "notice", AIM_SYSLOG_FLAG_NOTICE },
+    { "info", AIM_SYSLOG_FLAG_INFO },
+    { "debug", AIM_SYSLOG_FLAG_DEBUG },
+    { NULL, 0 }
+};
+
+aim_map_si_t aim_syslog_flag_desc_map[] =
+{
+    { "None", AIM_SYSLOG_FLAG_EMERG },
+    { "None", AIM_SYSLOG_FLAG_ALERT },
+    { "None", AIM_SYSLOG_FLAG_CRIT },
+    { "None", AIM_SYSLOG_FLAG_ERROR },
+    { "None", AIM_SYSLOG_FLAG_WARN },
+    { "None", AIM_SYSLOG_FLAG_NOTICE },
+    { "None", AIM_SYSLOG_FLAG_INFO },
+    { "None", AIM_SYSLOG_FLAG_DEBUG },
+    { NULL, 0 }
+};
+
+const char*
+aim_syslog_flag_name(aim_syslog_flag_t e)
+{
+    const char* name;
+    if(aim_map_si_i(&name, e, aim_syslog_flag_map, 0)) {
+        return name;
+    }
+    else {
+        return "-invalid value for enum type 'aim_syslog_flag'";
+    }
+}
+
+int
+aim_syslog_flag_value(const char* str, aim_syslog_flag_t* e, int substr)
+{
+    int i;
+    AIM_REFERENCE(substr);
+    if(aim_map_si_s(&i, str, aim_syslog_flag_map, 0)) {
+        /* Enum Found */
+        *e = i;
+        return 0;
+    }
+    else {
+        return -1;
+    }
+}
+
+const char*
+aim_syslog_flag_desc(aim_syslog_flag_t e)
+{
+    const char* name;
+    if(aim_map_si_i(&name, e, aim_syslog_flag_desc_map, 0)) {
+        return name;
+    }
+    else {
+        return "-invalid value for enum type 'aim_syslog_flag'";
+    }
+}
+
+
 aim_map_si_t aim_log_bit_map[] =
 {
     { "msg", AIM_LOG_BIT_MSG },
@@ -244,70 +374,6 @@ int
 aim_log_bit_valid(aim_log_bit_t e)
 {
     return aim_map_si_i(NULL, e, aim_log_bit_map, 0) ? 1 : 0;
-}
-
-
-aim_map_si_t aim_error_map[] =
-{
-    { "none", AIM_ERROR_NONE },
-    { "param", AIM_ERROR_PARAM },
-    { "not_found", AIM_ERROR_NOT_FOUND },
-    { "internal", AIM_ERROR_INTERNAL },
-    { NULL, 0 }
-};
-
-aim_map_si_t aim_error_desc_map[] =
-{
-    { "No error.", AIM_ERROR_NONE },
-    { "One of the function parameters was invalid.", AIM_ERROR_PARAM },
-    { "The requested object was not found.", AIM_ERROR_NOT_FOUND },
-    { "An unexpected internal error occurred.", AIM_ERROR_INTERNAL },
-    { NULL, 0 }
-};
-
-const char*
-aim_error_name(aim_error_t e)
-{
-    const char* name;
-    if(aim_map_si_i(&name, e, aim_error_map, 0)) {
-        return name;
-    }
-    else {
-        return "-invalid value for enum type 'aim_error'";
-    }
-}
-
-int
-aim_error_value(const char* str, aim_error_t* e, int substr)
-{
-    int i;
-    AIM_REFERENCE(substr);
-    if(aim_map_si_s(&i, str, aim_error_map, 0)) {
-        /* Enum Found */
-        *e = i;
-        return 0;
-    }
-    else {
-        return -1;
-    }
-}
-
-const char*
-aim_error_desc(aim_error_t e)
-{
-    const char* name;
-    if(aim_map_si_i(&name, e, aim_error_desc_map, 0)) {
-        return name;
-    }
-    else {
-        return "-invalid value for enum type 'aim_error'";
-    }
-}
-
-int
-aim_error_valid(aim_error_t e)
-{
-    return aim_map_si_i(NULL, e, aim_error_map, 0) ? 1 : 0;
 }
 
 

--- a/sourcegen/caimlogen.py
+++ b/sourcegen/caimlogen.py
@@ -77,7 +77,7 @@ class CAIMCommonLogMacroGenerator(CObjectGenerator):
     AIM_LOG_OBJ_COMMON(_obj, %(NAME)s, __VA_ARGS__)
 /** Log an object-level %(name)s with ratelimiting */
 #define AIM_LOG_OBJ_RL_%(NAME)s(_obj, _rl, _time, ...) \\
-    AIM_LOG_OBJ_RL_COMMON(_obj, _rl, _time, %(NAME)s, __VA_ARGS__)
+    AIM_LOG_OBJ_RL_COMMON(_obj, %(NAME)s, _rl, _time, __VA_ARGS__)
 
 """ % dict(NAME=f.upper(), name=f.lower())
 
@@ -94,7 +94,7 @@ class CAIMCommonLogMacroGenerator(CObjectGenerator):
 /** %(NAME)s -> OBJ_%(NAME)s */
 #define AIM_LOG_%(NAME)s AIM_LOG_OBJ_%(NAME)s
 /** RL_%(NAME)s -> OBJ_RL_%(NAME)s */
-#define AIM_LOG_RL_%(NAME)s AIM_LOG_RL_OBJ_%(NAME)s
+#define AIM_LOG_RL_%(NAME)s AIM_LOG_OBJ_RL_%(NAME)s
 
 """ % dict(NAME=f.upper(), name=f.lower())
 


### PR DESCRIPTION
Reviewer: @jnealtowns 
CC: @rlane 

AIM_SYSLOG_\* macros will also invoke AIM_LOG_MOD_\* at MSG level.

For review only; please do not ack.  Only unit-tested; needs integration testing.  Thanks.
