### PR TITLE
AIM: enable MSG logs by default

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_log.h
+++ b/modules/AIM/module/inc/AIM/aim_log.h
@@ -218,7 +218,7 @@ typedef struct aim_log_s {
  */
 #define AIM_LOG_BITS_BASELINE                                     \
     (AIM_LOG_BIT_FATAL + AIM_LOG_BIT_ERROR + AIM_LOG_BIT_WARN +   \
-     AIM_LOG_BIT_BUG + AIM_LOG_BIT_INTERNAL +                     \
+     AIM_LOG_BIT_BUG + AIM_LOG_BIT_INTERNAL + AIM_LOG_BIT_MSG +   \
      AIM_LOG_BIT_SYSLOG_EMERG + AIM_LOG_BIT_SYSLOG_ALERT +        \
      AIM_LOG_BIT_SYSLOG_CRIT + AIM_LOG_BIT_SYSLOG_ERROR +         \
      AIM_LOG_BIT_SYSLOG_WARN + AIM_LOG_BIT_SYSLOG_NOTICE +        \


### PR DESCRIPTION
Reviewer: @jnealtowns

I assume the intent of MSG is for logs that aren't errors but should always be 
displayed.