### PR TITLE
AIM: double the number of arguments supported by AIM_VA_ARGS_NUM

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_valist.h
+++ b/modules/AIM/module/inc/AIM/aim_valist.h
@@ -108,7 +108,7 @@ typedef struct aim_va_list_s {
 #define AIM_VA_ARGS_REST_HELPER_TWOORMORE(_first, ...) , __VA_ARGS__
 /** internal */
 #define AIM_VA_ARGS_NUM(...)                                            \
-    AIM_VA_ARGS_SELECT_30TH(__VA_ARGS__, \
+    AIM_VA_ARGS_SELECT_60TH(__VA_ARGS__, \
                             TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
                             TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
                             TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
@@ -116,11 +116,21 @@ typedef struct aim_va_list_s {
                             TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
                             TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
                             TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
-                            ONE, ignore)
+                            TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
+                            TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
+                            TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
+                            TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
+                            TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
+                            TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
+                            TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, \
+                            TWOORMORE, TWOORMORE, ONE, ignore)
 /** internal */
-#define AIM_VA_ARGS_SELECT_30TH(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, \
+#define AIM_VA_ARGS_SELECT_60TH(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, \
                                 a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, \
-                                a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, ...) a30
+                                a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, \
+                                a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, \
+                                a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, \
+                                a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, ...) a60
 
 
 


### PR DESCRIPTION
Reviewer: @jnealtowns

I have a log that uses more than 30 arguments.