### PR TITLE
AIM: output file and line info for fatal logs

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_utils.h
+++ b/modules/AIM/module/inc/AIM/aim_utils.h
@@ -184,8 +184,7 @@ extern int aim_modules_init(void);
         int _rv;                                                \
         _rv = (_expr);                                          \
         if(_rv < 0) {                                           \
-            AIM_LOG_FATAL("'%s' returned %d @%s:%d",            \
-                          #_expr, _rv, __FILE__, __LINE__);     \
+            AIM_LOG_FATAL("'%s' returned %d", #_expr, _rv);     \
             exit(1);                                            \
         }                                                       \
     } while(0)

--- a/modules/AIM/module/src/aim_log.c
+++ b/modules/AIM/module/src/aim_log.c
@@ -510,7 +510,8 @@ aim_log_output__(aim_log_t* l, aim_log_flag_t flag,
     if(l->options & (1 << AIM_LOG_OPTION_FUNC)) {
         aim_printf(msg, " [%s]", fname);
     }
-    if(l->options & (1 << AIM_LOG_OPTION_FILE_LINE)) {
+    if(l->options & (1 << AIM_LOG_OPTION_FILE_LINE)
+            || flag == AIM_LOG_FLAG_FATAL) {
         aim_printf(msg, " [%s:%d]", file, line);
     }
     aim_printf(msg, "\n");


### PR DESCRIPTION
Reviewer: @jnealtowns

It would be helpful to see the file/line for AIM_DIE, AIM_ASSERT, and 
AIM_TRUE_OR_DIE. This change overrides the log struct options for fatal logs
to enable AIM_LOG_OPTION_FILE_LINE.

Also removes the file and line from AIM_TRY_OR_DIE, since it would be 
redundant.