### PR TITLE
AIM: increase ratelimiter interval to 64 bits

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_rl.h
+++ b/modules/AIM/module/inc/AIM/aim_rl.h
@@ -51,9 +51,9 @@ typedef uint64_t (*aim_ratelimiter_monotonic_f)(void);
  */
 typedef struct aim_ratelimiter_s {
     /** Averate time units per event (inverse of the rate) */
-    uint32_t interval;
+    uint64_t interval;
     /** Depth of bucket. */
-    uint32_t burst;
+    uint64_t burst;
     /** Time in the future the bucket will become empty. */
     uint64_t empty_time;
     /** monotonic timer (optional) */
@@ -71,8 +71,8 @@ typedef struct aim_ratelimiter_s {
  * @note If you don't specify the timer, you must always pass the current
  * time to the ratelimiter functions.
  */
-void aim_ratelimiter_init(aim_ratelimiter_t* rl, uint32_t interval,
-                          uint32_t burst, aim_ratelimiter_monotonic_f monotonic);
+void aim_ratelimiter_init(aim_ratelimiter_t* rl, uint64_t interval,
+                          uint64_t burst, aim_ratelimiter_monotonic_f monotonic);
 
 /**
  * @brief Rate limit check.

--- a/modules/AIM/module/src/aim_rl.c
+++ b/modules/AIM/module/src/aim_rl.c
@@ -27,8 +27,8 @@
 #include "aim_util.h"
 
 void
-aim_ratelimiter_init(aim_ratelimiter_t* rl, uint32_t interval,
-                     uint32_t burst, aim_ratelimiter_monotonic_f monotonic)
+aim_ratelimiter_init(aim_ratelimiter_t* rl, uint64_t interval,
+                     uint64_t burst, aim_ratelimiter_monotonic_f monotonic)
 {
     if(rl) {
         AIM_MEMSET(rl, 0, sizeof(*rl));


### PR DESCRIPTION
Reviewer: @jnealtowns

I'd like to use CPU cycles as the unit in a ratelimiter but 32 bits isn't 
enough to hold a few seconds worth.