### PR TITLE
Builtin Log Handler

### DIFF
--- a/modules/AIM/module/auto/AIM.yml
+++ b/modules/AIM/module/auto/AIM.yml
@@ -90,7 +90,6 @@ cdefs: &cdefs
     doc: "Default facility for openlog()"
     default: LOG_DAEMON
 
-
 aim_error_types: &aim_error_types
 - none:
     value: 0
@@ -146,6 +145,22 @@ aim_log_bits: &aim_log_bits
 - syslog_info:    (1 << AIM_LOG_FLAG_SYSLOG_INFO)
 - syslog_debug:   (1 << AIM_LOG_FLAG_SYSLOG_DEBUG)
 
+
+aim_log_handler_options: &aim_log_handler_options
+- set_all
+- to_dbglog
+- to_syslog
+- to_stdout
+- to_stderr
+
+aim_log_handler_flags: &aim_log_handler_flags
+- set_all:          (1 << AIM_LOG_HANDLER_OPTION_SET_ALL)
+- to_dbglog:        (1 << AIM_LOG_HANDLER_OPTION_TO_DBGLOG)
+- to_syslog:        (1 << AIM_LOG_HANDLER_OPTION_TO_SYSLOG)
+- to_stdout:        (1 << AIM_LOG_HANDLER_OPTION_TO_STDOUT)
+- to_stderr:        (1 << AIM_LOG_HANDLER_OPTION_TO_STDERR)
+
+
 definitions:
   cdefs:
     AIM_CONFIG_HEADER:
@@ -181,6 +196,13 @@ definitions:
 
     aim_error:
       members: *aim_error_types
+
+    aim_log_handler_option:
+      members: *aim_log_handler_options
+
+    aim_log_handler_flag:
+      linear: false
+      members: *aim_log_handler_flags
 
   portingmacro:
     AIM:

--- a/modules/AIM/module/auto/AIM.yml
+++ b/modules/AIM/module/auto/AIM.yml
@@ -150,14 +150,12 @@ aim_log_bits: &aim_log_bits
 
 
 aim_log_handler_options: &aim_log_handler_options
-- set_all
 - to_dbglog
 - to_syslog
 - to_stdout
 - to_stderr
 
 aim_log_handler_flags: &aim_log_handler_flags
-- set_all:          (1 << AIM_LOG_HANDLER_OPTION_SET_ALL)
 - to_dbglog:        (1 << AIM_LOG_HANDLER_OPTION_TO_DBGLOG)
 - to_syslog:        (1 << AIM_LOG_HANDLER_OPTION_TO_SYSLOG)
 - to_stdout:        (1 << AIM_LOG_HANDLER_OPTION_TO_STDOUT)
@@ -201,9 +199,11 @@ definitions:
       members: *aim_error_types
 
     aim_log_handler_option:
+      tag: log_handler
       members: *aim_log_handler_options
 
     aim_log_handler_flag:
+      tag: log_handler
       linear: false
       members: *aim_log_handler_flags
 

--- a/modules/AIM/module/inc/AIM/aim.h
+++ b/modules/AIM/module/inc/AIM/aim.h
@@ -47,6 +47,7 @@
 #include <AIM/aim_bitmap.h>
 #include <AIM/aim_daemon.h>
 #include <AIM/aim_memory.h>
+#include <AIM/aim_log_handler.h>
 
 #endif /* __AIM_H__ */
 /*@}*/

--- a/modules/AIM/module/inc/AIM/aim_config.h
+++ b/modules/AIM/module/inc/AIM/aim_config.h
@@ -209,7 +209,7 @@ struct aim_pvs_s;
 
 
 #ifndef AIM_CONFIG_INCLUDE_DAEMONIZE
-#define AIM_CONFIG_INCLUDE_DAEMONIZE 0
+#define AIM_CONFIG_INCLUDE_DAEMONIZE 1
 #endif
 
 /**

--- a/modules/AIM/module/inc/AIM/aim_log.h
+++ b/modules/AIM/module/inc/AIM/aim_log.h
@@ -234,9 +234,7 @@ typedef struct aim_log_s {
  * Reasonable default option settings.
  */
 #ifndef AIM_LOG_OPTIONS_DEFAULT
-#define AIM_LOG_OPTIONS_DEFAULT                  \
-    ( AIM_LOG_OPTION_BIT_ENABLE +                \
-      AIM_LOG_OPTION_BIT_TIMESTAMP )
+#define AIM_LOG_OPTIONS_DEFAULT AIM_LOG_OPTION_BIT_ENABLE
 #endif
 
 

--- a/modules/AIM/module/inc/AIM/aim_log.h
+++ b/modules/AIM/module/inc/AIM/aim_log.h
@@ -234,7 +234,9 @@ typedef struct aim_log_s {
  * Reasonable default option settings.
  */
 #ifndef AIM_LOG_OPTIONS_DEFAULT
-#define AIM_LOG_OPTIONS_DEFAULT AIM_LOG_OPTION_BIT_ENABLE
+#define AIM_LOG_OPTIONS_DEFAULT                        \
+    ( AIM_LOG_OPTION_BIT_ENABLE +                      \
+      AIM_LOG_OPTION_BIT_TIMESTAMP )
 #endif
 
 

--- a/modules/AIM/module/inc/AIM/aim_log_handler.h
+++ b/modules/AIM/module/inc/AIM/aim_log_handler.h
@@ -1,0 +1,179 @@
+/****************************************************************
+ *
+ *        Copyright 2013,2014,2015,2016 Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+#ifndef __AIM_LOG_HANDLER_H__
+#define __AIM_LOG_HANDLER_H__
+
+/* <auto.start.enum(aim_log_handler_option).define> */
+/** aim_log_handler_option */
+typedef enum aim_log_handler_option_e {
+    AIM_LOG_HANDLER_OPTION_TO_DBGLOG,
+    AIM_LOG_HANDLER_OPTION_TO_SYSLOG,
+    AIM_LOG_HANDLER_OPTION_TO_STDOUT,
+    AIM_LOG_HANDLER_OPTION_TO_STDERR,
+    AIM_LOG_HANDLER_OPTION_LAST = AIM_LOG_HANDLER_OPTION_TO_STDERR,
+    AIM_LOG_HANDLER_OPTION_COUNT,
+    AIM_LOG_HANDLER_OPTION_INVALID = -1,
+} aim_log_handler_option_t;
+/* <auto.end.enum(aim_log_handler_option).define> */
+
+/* <auto.start.enum(aim_log_handler_flag).define> */
+/** aim_log_handler_flag */
+typedef enum aim_log_handler_flag_e {
+    AIM_LOG_HANDLER_FLAG_TO_DBGLOG = (1 << AIM_LOG_HANDLER_OPTION_TO_DBGLOG),
+    AIM_LOG_HANDLER_FLAG_TO_SYSLOG = (1 << AIM_LOG_HANDLER_OPTION_TO_SYSLOG),
+    AIM_LOG_HANDLER_FLAG_TO_STDOUT = (1 << AIM_LOG_HANDLER_OPTION_TO_STDOUT),
+    AIM_LOG_HANDLER_FLAG_TO_STDERR = (1 << AIM_LOG_HANDLER_OPTION_TO_STDERR),
+} aim_log_handler_flag_t;
+/* <auto.end.enum(aim_log_handler_flag).define> */
+
+
+/**
+ * Configuration block.
+ */
+typedef struct aim_log_handler_config_s {
+    /** Flags: see AIM_LOG_HANDLER_FLAG_* above */
+    uint32_t flags;
+
+    /** Name of debug log file, optionally with full or relative path */
+    char* debug_log_name;
+
+    /** Maximum number of bytes beyond which the debug log will be rotated */
+    uint32_t max_debug_log_size;
+
+    /** Maximum number of rotated debug logs, excluding the actual debug log */
+    uint32_t max_debug_logs;
+
+    /** Syslog facility to use (if applicable) */
+    uint32_t syslog_facility;
+
+} aim_log_handler_config_t;
+
+
+typedef struct aim_log_handler_s* aim_log_handler_t;
+
+
+/**
+ * @brief Initialize the AIM log handler system.
+ */
+void aim_log_handler_init(void);
+
+/**
+ * @brief Deinitialize the AIM log handler system.
+ */
+void aim_log_handler_denit(void);
+
+
+/**
+ * Create an AIM log handler instance.
+ * @param config The handler configurtion.
+ * @returns Object pointer.
+ */
+
+aim_log_handler_t aim_log_handler_create(aim_log_handler_config_t* config);
+
+/**
+ * Destroy an AIM log handler instance.
+ */
+void aim_log_handler_destroy(aim_log_handler_t handler);
+
+
+/**
+ * @brief AIM log handler callback.
+ * @param Cookie log handler cookie. Must be an aim_log_handler_t.
+ * @param flag The AIM log flag.
+ * @param str The log message.
+ */
+void aim_log_handler_logf(void* cookie, aim_log_flag_t flag, const char* str);
+
+
+
+/**
+ * @brief Basic initialization for console and daemonized clients.
+ * @param ident The syslog ident to use (optional)
+ * @param debug_log_file  The name of the debug log file (optional)
+ * @param max_debug_size   Maximum debug log size.
+ * @param max_debug_count  Maximum number of rotated debug logs.
+ *
+ * @note This is designed to be a simple and generic initialization
+ * for both daemonized and console-based clients. It will initialize
+ */
+int aim_log_handler_basic_init_all(const char* ident,
+                                    const char* debug_log_file,
+                                    int max_debug_log_size,
+                                    int max_debug_logs);
+
+/**
+ * @brief Deinitialize basic log handling support.
+ */
+void aim_log_handler_basic_denit_all(void);
+
+
+
+
+/* <auto.start.enum(tag:log_handler).supportheader> */
+/** Enum names. */
+const char* aim_log_handler_flag_name(aim_log_handler_flag_t e);
+
+/** Enum values. */
+int aim_log_handler_flag_value(const char* str, aim_log_handler_flag_t* e, int substr);
+
+/** Enum descriptions. */
+const char* aim_log_handler_flag_desc(aim_log_handler_flag_t e);
+
+/** Enum validator. */
+int aim_log_handler_flag_valid(aim_log_handler_flag_t e);
+
+/** validator */
+#define AIM_LOG_HANDLER_FLAG_VALID(_e) \
+    (aim_log_handler_flag_valid((_e)))
+
+/** aim_log_handler_flag_map table. */
+extern aim_map_si_t aim_log_handler_flag_map[];
+/** aim_log_handler_flag_desc_map table. */
+extern aim_map_si_t aim_log_handler_flag_desc_map[];
+
+/** Strings macro. */
+#define AIM_LOG_HANDLER_OPTION_STRINGS \
+{\
+    "to_dbglog", \
+    "to_syslog", \
+    "to_stdout", \
+    "to_stderr", \
+}
+/** Enum names. */
+const char* aim_log_handler_option_name(aim_log_handler_option_t e);
+
+/** Enum values. */
+int aim_log_handler_option_value(const char* str, aim_log_handler_option_t* e, int substr);
+
+/** Enum descriptions. */
+const char* aim_log_handler_option_desc(aim_log_handler_option_t e);
+
+/** validator */
+#define AIM_LOG_HANDLER_OPTION_VALID(_e) \
+    ( (0 <= (_e)) && ((_e) <= AIM_LOG_HANDLER_OPTION_TO_STDERR))
+
+/** aim_log_handler_option_map table. */
+extern aim_map_si_t aim_log_handler_option_map[];
+/** aim_log_handler_option_desc_map table. */
+extern aim_map_si_t aim_log_handler_option_desc_map[];
+/* <auto.end.enum(tag:log_handler).supportheader> */
+
+#endif /* __AIM_LOG_HANDLER_H__ */
+/* @}*/

--- a/modules/AIM/module/inc/AIM/aim_log_handler.h
+++ b/modules/AIM/module/inc/AIM/aim_log_handler.h
@@ -111,12 +111,12 @@ void aim_log_handler_logf(void* cookie, aim_log_flag_t flag, const char* str);
  * @param max_debug_count  Maximum number of rotated debug logs.
  *
  * @note This is designed to be a simple and generic initialization
- * for both daemonized and console-based clients. It will initialize
+ * for both daemonized and console-based clients.
  */
 int aim_log_handler_basic_init_all(const char* ident,
-                                    const char* debug_log_file,
-                                    int max_debug_log_size,
-                                    int max_debug_logs);
+                                   const char* debug_log_file,
+                                   int max_debug_log_size,
+                                   int max_debug_logs);
 
 /**
  * @brief Deinitialize basic log handling support.

--- a/modules/AIM/module/src/aim_enums.c
+++ b/modules/AIM/module/src/aim_enums.c
@@ -273,6 +273,128 @@ aim_log_flag_desc(aim_log_flag_t e)
 }
 
 
+aim_map_si_t aim_log_handler_flag_map[] =
+{
+    { "to_dbglog", AIM_LOG_HANDLER_FLAG_TO_DBGLOG },
+    { "to_syslog", AIM_LOG_HANDLER_FLAG_TO_SYSLOG },
+    { "to_stdout", AIM_LOG_HANDLER_FLAG_TO_STDOUT },
+    { "to_stderr", AIM_LOG_HANDLER_FLAG_TO_STDERR },
+    { NULL, 0 }
+};
+
+aim_map_si_t aim_log_handler_flag_desc_map[] =
+{
+    { "None", AIM_LOG_HANDLER_FLAG_TO_DBGLOG },
+    { "None", AIM_LOG_HANDLER_FLAG_TO_SYSLOG },
+    { "None", AIM_LOG_HANDLER_FLAG_TO_STDOUT },
+    { "None", AIM_LOG_HANDLER_FLAG_TO_STDERR },
+    { NULL, 0 }
+};
+
+const char*
+aim_log_handler_flag_name(aim_log_handler_flag_t e)
+{
+    const char* name;
+    if(aim_map_si_i(&name, e, aim_log_handler_flag_map, 0)) {
+        return name;
+    }
+    else {
+        return "-invalid value for enum type 'aim_log_handler_flag'";
+    }
+}
+
+int
+aim_log_handler_flag_value(const char* str, aim_log_handler_flag_t* e, int substr)
+{
+    int i;
+    AIM_REFERENCE(substr);
+    if(aim_map_si_s(&i, str, aim_log_handler_flag_map, 0)) {
+        /* Enum Found */
+        *e = i;
+        return 0;
+    }
+    else {
+        return -1;
+    }
+}
+
+const char*
+aim_log_handler_flag_desc(aim_log_handler_flag_t e)
+{
+    const char* name;
+    if(aim_map_si_i(&name, e, aim_log_handler_flag_desc_map, 0)) {
+        return name;
+    }
+    else {
+        return "-invalid value for enum type 'aim_log_handler_flag'";
+    }
+}
+
+int
+aim_log_handler_flag_valid(aim_log_handler_flag_t e)
+{
+    return aim_map_si_i(NULL, e, aim_log_handler_flag_map, 0) ? 1 : 0;
+}
+
+
+aim_map_si_t aim_log_handler_option_map[] =
+{
+    { "to_dbglog", AIM_LOG_HANDLER_OPTION_TO_DBGLOG },
+    { "to_syslog", AIM_LOG_HANDLER_OPTION_TO_SYSLOG },
+    { "to_stdout", AIM_LOG_HANDLER_OPTION_TO_STDOUT },
+    { "to_stderr", AIM_LOG_HANDLER_OPTION_TO_STDERR },
+    { NULL, 0 }
+};
+
+aim_map_si_t aim_log_handler_option_desc_map[] =
+{
+    { "None", AIM_LOG_HANDLER_OPTION_TO_DBGLOG },
+    { "None", AIM_LOG_HANDLER_OPTION_TO_SYSLOG },
+    { "None", AIM_LOG_HANDLER_OPTION_TO_STDOUT },
+    { "None", AIM_LOG_HANDLER_OPTION_TO_STDERR },
+    { NULL, 0 }
+};
+
+const char*
+aim_log_handler_option_name(aim_log_handler_option_t e)
+{
+    const char* name;
+    if(aim_map_si_i(&name, e, aim_log_handler_option_map, 0)) {
+        return name;
+    }
+    else {
+        return "-invalid value for enum type 'aim_log_handler_option'";
+    }
+}
+
+int
+aim_log_handler_option_value(const char* str, aim_log_handler_option_t* e, int substr)
+{
+    int i;
+    AIM_REFERENCE(substr);
+    if(aim_map_si_s(&i, str, aim_log_handler_option_map, 0)) {
+        /* Enum Found */
+        *e = i;
+        return 0;
+    }
+    else {
+        return -1;
+    }
+}
+
+const char*
+aim_log_handler_option_desc(aim_log_handler_option_t e)
+{
+    const char* name;
+    if(aim_map_si_i(&name, e, aim_log_handler_option_desc_map, 0)) {
+        return name;
+    }
+    else {
+        return "-invalid value for enum type 'aim_log_handler_option'";
+    }
+}
+
+
 aim_map_si_t aim_log_option_map[] =
 {
     { "enable", AIM_LOG_OPTION_ENABLE },

--- a/modules/AIM/module/src/aim_log_handler.c
+++ b/modules/AIM/module/src/aim_log_handler.c
@@ -1,0 +1,274 @@
+/****************************************************************
+ *
+ *        Copyright 2013,2014,2015,2016 Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+#include <AIM/aim_config.h>
+#include <AIM/aim_map.h>
+#include <AIM/aim_error.h>
+#include <AIM/aim_log.h>
+#include <AIM/aim_sem.h>
+#include <AIM/aim_log_handler.h>
+#include <AIM/aim_memory.h>
+#include <AIM/aim_string.h>
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <time.h>
+#include <syslog.h>
+#include <errno.h>
+
+
+/**
+ * This lock is used to syncronized output to stdout/stderr.
+ */
+static aim_sem_t stdio_lock__ = NULL;
+
+void
+aim_log_handler_init(void)
+{
+    if(stdio_lock__ == NULL) {
+        stdio_lock__ = aim_sem_create(1);
+    }
+}
+
+void
+aim_log_handler_denit(void)
+{
+    if(stdio_lock__) {
+        aim_sem_destroy(stdio_lock__);
+        stdio_lock__ = NULL;
+    }
+}
+
+struct aim_log_handler_s {
+    aim_log_handler_config_t config;
+    aim_sem_t debug_lock;
+    FILE* debug_fp;
+};
+
+aim_log_handler_t
+aim_log_handler_create(aim_log_handler_config_t* config)
+{
+    aim_log_handler_t rv;
+
+    rv = aim_zmalloc(sizeof(*rv));
+    AIM_MEMCPY(&rv->config, config, sizeof(rv->config));
+
+    if(config->debug_log_name) {
+        rv->config.debug_log_name = aim_strdup(config->debug_log_name);
+        rv->debug_fp = fopen(rv->config.debug_log_name, "a");
+        rv->debug_lock = aim_sem_create(1);
+    }
+
+    return rv;
+}
+
+void
+aim_log_handler_destroy(aim_log_handler_t handler)
+{
+    if(handler->config.debug_log_name) {
+        aim_free(handler->config.debug_log_name);
+    }
+
+    if(handler->debug_fp) {
+        fclose(handler->debug_fp);
+    }
+
+    if(handler->debug_lock) {
+        aim_sem_destroy(handler->debug_lock);
+    }
+
+    aim_free(handler);
+}
+
+static void
+rotate_debug_log__(aim_log_handler_t handler)
+{
+    struct stat fp_log_stat;
+    if (stat(handler->config.debug_log_name, &fp_log_stat) != -1) {
+        if (fp_log_stat.st_size >= handler->config.max_debug_log_size) {
+
+            int debug_log_name_len = strlen(handler->config.debug_log_name);
+            char* src = aim_malloc(debug_log_name_len + 16);
+            char* dst = aim_malloc(debug_log_name_len + 16);
+
+            int i;
+
+            /* move older logs first */
+            for (i = handler->config.max_debug_logs-1; i >= 1; i--) {
+                sprintf(src, "%s.%d", handler->config.debug_log_name, i);
+                sprintf(dst, "%s.%d", handler->config.debug_log_name, i+1);
+                rename(src, dst);
+            }
+
+            /* close log, move it to .1, and open a new file */
+            sprintf(dst, "%s.1", handler->config.debug_log_name);
+            fclose(handler->debug_fp);
+            rename(handler->config.debug_log_name, dst);
+            handler->debug_fp = fopen(handler->config.debug_log_name, "a");
+        }
+    }
+}
+
+/* prepend time to log message and flush out to debug log file */
+static void
+debug_log__(aim_log_handler_t handler,
+            aim_log_flag_t flag, const char* str)
+{
+    struct timeval timeval;
+    struct tm *loctime;
+    char lt[128];
+
+    if(handler->debug_fp == NULL) {
+        return;
+    }
+
+    gettimeofday(&timeval, NULL);
+    loctime = localtime(&timeval.tv_sec);
+    strftime(lt, sizeof(lt), "%FT%T", loctime);
+
+    aim_sem_take(handler->debug_lock);
+
+    fprintf(handler->debug_fp, "%s.%.06d %s %s", lt,
+            (int)timeval.tv_usec, aim_log_flag_name(flag), str);
+    fflush(handler->debug_fp);
+
+    rotate_debug_log__(handler);
+
+    aim_sem_give(handler->debug_lock);
+}
+
+
+void
+aim_log_handler_logf(void* cookie, aim_log_flag_t flag, const char* str)
+{
+    aim_log_handler_t handler = (aim_log_handler_t)cookie;
+    uint32_t priority = handler->config.syslog_facility;
+    int to_syslog = 0;
+
+    if(!strcmp(str, "\n")) {
+        return;
+    }
+
+    /* generate severity from flag */
+    switch (flag) {
+    case AIM_LOG_FLAG_SYSLOG_EMERG:
+        to_syslog = 1;
+        priority |= LOG_EMERG;
+        break;
+    case AIM_LOG_FLAG_SYSLOG_ALERT:
+        to_syslog = 1;
+        priority |= LOG_ALERT;
+        break;
+    case AIM_LOG_FLAG_SYSLOG_CRIT:
+        to_syslog = 1;
+        priority |= LOG_CRIT;
+        break;
+    case AIM_LOG_FLAG_SYSLOG_ERROR:
+        to_syslog = 1;
+        priority |= LOG_ERR;
+        break;
+    case AIM_LOG_FLAG_SYSLOG_WARN:
+        to_syslog = 1;
+        priority |= LOG_WARNING;
+        break;
+    case AIM_LOG_FLAG_SYSLOG_NOTICE:
+        to_syslog = 1;
+        priority |= LOG_NOTICE;
+        break;
+    case AIM_LOG_FLAG_SYSLOG_INFO:
+        to_syslog = 1;
+        priority |= LOG_INFO;
+        break;
+    case AIM_LOG_FLAG_SYSLOG_DEBUG:
+        to_syslog = 1;
+        priority |= LOG_DEBUG;
+        break;
+    default:
+        to_syslog = 0;
+        break;
+    }
+
+    if (to_syslog && handler->config.flags & AIM_LOG_HANDLER_FLAG_TO_SYSLOG) {
+        syslog(priority, "%s", str);
+    }
+
+    if(handler->config.flags & (AIM_LOG_HANDLER_FLAG_TO_STDOUT + AIM_LOG_HANDLER_FLAG_TO_STDERR)) {
+        aim_sem_take(stdio_lock__);
+        if (handler->config.flags & AIM_LOG_HANDLER_FLAG_TO_STDOUT) {
+            fprintf(stdout, "%s", str);
+        }
+        if (handler->config.flags & AIM_LOG_HANDLER_FLAG_TO_STDERR) {
+            fprintf(stderr, "%s", str);
+        }
+        aim_sem_give(stdio_lock__);
+    }
+
+    if (handler->config.flags & AIM_LOG_HANDLER_FLAG_TO_DBGLOG) {
+        debug_log__(handler, flag, str);
+    }
+}
+
+
+
+static aim_log_handler_t basic_handler__ = NULL;
+
+int
+aim_log_handler_basic_init_all(const char* ident,
+                           const char* debug_log,
+                           int max_debug_log_size,
+                           int max_debug_logs)
+{
+    aim_log_handler_config_t config;
+    AIM_MEMSET(&config, 0, sizeof(config));
+
+    if(isatty(1)) {
+        /** Assume interactive and log to stdout */
+        config.flags |= AIM_LOG_HANDLER_FLAG_TO_STDOUT;
+    }
+    else if(ident) {
+        /** Assume daemonized and send to syslog */
+        openlog(ident, LOG_PID, LOG_DAEMON);
+        config.flags |= AIM_LOG_HANDLER_FLAG_TO_SYSLOG;
+        config.syslog_facility = LOG_DAEMON;
+    }
+
+    if(debug_log) {
+        /** Log to debug log file */
+        config.flags |= AIM_LOG_HANDLER_FLAG_TO_DBGLOG;
+        config.debug_log_name = aim_strdup(debug_log);
+        config.max_debug_log_size = max_debug_log_size;
+        config.max_debug_logs = max_debug_logs;
+    }
+
+    basic_handler__ = aim_log_handler_create(&config);
+    aim_logf_set_all("{aim_log_handler}", aim_log_handler_logf, basic_handler__);
+    return 0;
+}
+
+
+void
+aim_log_handler_basic_denit_all(void)
+{
+    aim_log_pvs_set_all(&aim_pvs_stderr);
+    aim_log_handler_destroy(basic_handler__);
+    basic_handler__ = NULL;
+}
+
+

--- a/modules/AIM/module/src/aim_log_handler.c
+++ b/modules/AIM/module/src/aim_log_handler.c
@@ -122,6 +122,9 @@ rotate_debug_log__(aim_log_handler_t handler)
             fclose(handler->debug_fp);
             rename(handler->config.debug_log_name, dst);
             handler->debug_fp = fopen(handler->config.debug_log_name, "a");
+
+            aim_free(src);
+            aim_free(dst);
         }
     }
 }
@@ -270,5 +273,3 @@ aim_log_handler_basic_denit_all(void)
     aim_log_handler_destroy(basic_handler__);
     basic_handler__ = NULL;
 }
-
-

--- a/modules/AIM/module/src/aim_log_handler.c
+++ b/modules/AIM/module/src/aim_log_handler.c
@@ -262,6 +262,7 @@ aim_log_handler_basic_init_all(const char* ident,
 
     basic_handler__ = aim_log_handler_create(&config);
     aim_logf_set_all("{aim_log_handler}", aim_log_handler_logf, basic_handler__);
+    aim_log_option_set_all(AIM_LOG_OPTION_TIMESTAMP, 0);
     return 0;
 }
 

--- a/modules/AIM/module/src/aim_module.c
+++ b/modules/AIM/module/src/aim_module.c
@@ -25,15 +25,18 @@
  *****************************************************************************/
 #include <AIM/aim_config.h>
 #include <AIM/aim_datatypes.h>
+#include <AIM/aim_log_handler.h>
 
 void
 __aim_module_init__(void)
 {
     aim_datatypes_init();
+    aim_log_handler_init();
 }
 
 void
 __aim_module_denit__(void)
 {
+    aim_log_handler_denit();
     aim_datatypes_denit();
 }


### PR DESCRIPTION
Reviewer: @kenchiang  @rlane 

This log handler supports the AIM_SYSLOG_* and AIM_LOG_* macros.
It also supports logging to stdout, stderr, and an optional debug log file.

This code was ported from private code initially implemented by @kenchiang.
