### PR TITLE
builder: remove extra slashes in paths

### DIFF
--- a/builder/unix/obj.mk
+++ b/builder/unix/obj.mk
@@ -28,12 +28,12 @@
 # TARGET is specified by the calling makefile.
 #
 ifndef $(TARGET)_SRCS
-$(TARGET)_SRCS := $(wildcard $($(TARGET)_SUBDIR)/*.c)
+$(TARGET)_SRCS := $(wildcard $($(TARGET)_SUBDIR)*.c)
 endif
 
 $(TARGET)_LSRCS := $(notdir $($(TARGET)_SRCS))
 $(TARGET)_LOBJS := $(addsuffix .o, $(basename $($(TARGET)_LSRCS)))
-$(TARGET)_OBJS := $(addprefix $(OBJECT_DIR)/$($(TARGET)_SUBDIR)/, $($(TARGET)_LOBJS)) $(EXTRA_$(TARGET)_OBJS)
+$(TARGET)_OBJS := $(addprefix $(OBJECT_DIR)$($(TARGET)_SUBDIR), $($(TARGET)_LOBJS)) $(EXTRA_$(TARGET)_OBJS)
 
 ALL_TARGETS := $(ALL_TARGETS) $(TARGET)
 
@@ -48,7 +48,7 @@ include $(TOOLCHAIN_DIR)/obj.mk
 # Add a rule to build all objects into the object directory based on
 # their relative path.
 #
-$($(TARGET)_SUBDIR)/%.o: $(OBJECT_DIR)/$($(TARGET)_SUBDIR)/%.o
+$($(TARGET)_SUBDIR)%.o: $(OBJECT_DIR)$($(TARGET)_SUBDIR)%.o
 
 
 #

--- a/builder/unix/toolchains/gcc-local/obj.mk
+++ b/builder/unix/toolchains/gcc-local/obj.mk
@@ -26,7 +26,7 @@ ifdef OBJECT_DIR
 
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-MAKE_DIR=$(OBJECT_DIR)/$($(TARGET)_SUBDIR)
+MAKE_DIR=$(OBJECT_DIR)$($(TARGET)_SUBDIR)
 include $(BUILDER)/makedir.mk
 
 ifndef GCC
@@ -105,14 +105,14 @@ endif
 
 # Rule to build object files from c files for this target.
 # Note that we also generate dependencies automatically with -MD
-$(OBJECT_DIR)/$($(TARGET)_SUBDIR)/%.o: $($(TARGET)_SUBDIR)/%.c
+$(OBJECT_DIR)$($(TARGET)_SUBDIR)%.o: $($(TARGET)_SUBDIR)%.c
 	@echo "    Compiling$(CINFO): $(TARGET)::$(notdir $<)"
 	$(VERBOSE) $(CCACHE) $(GCC) $(DEBUG_FLAGS) $(COVERAGE_FLAGS) $(ANALYZE_FLAGS) -I. $($(TARGET)_INCLUDES) $($(TARGET)_CFLAGS) $(GLOBAL_INCLUDES) $(GLOBAL_CFLAGS) $(GCC_PEDANTIC_FLAGS) $(GCC_FLAGS) $(GCC_WARNING_FLAGS) -MD -c $< -o $@
 
 # Dependecies Files for these targets
 $(TARGET)_DEPS := $($(TARGET)_OBJS:%.o=%.d)
 
-$(OBJECT_DIR)/$($(TARGET)_SUBDIR)/%.o: TARGET:=$(TARGET)
+$(OBJECT_DIR)$($(TARGET)_SUBDIR)%.o: TARGET:=$(TARGET)
 
 endif
 

--- a/builder/unix/tools/modulemakes.py
+++ b/builder/unix/tools/modulemakes.py
@@ -82,6 +82,7 @@ s = """
 for p in patterns:
     for f in found[p]:
         root = os.path.abspath(f['root'])
+        root = root.replace(os.path.abspath(ops.root)+"/", "$(%s_BASEDIR)" % (ops.name))
         root = root.replace(os.path.abspath(ops.root), "$(%s_BASEDIR)" % (ops.name))
         name = f['file']
         s += "include %s/%s\n" % (root, name)


### PR DESCRIPTION
Reviewer: @jnealtowns 

RPM has a [bug][1] that breaks debuginfo extraction when a filename in the
debug section has double slashes. There's some random chance involved which is
why we hadn't seen this problem before.

The main source of double slashes is `$(dir $(lastword $(MAKEFILE_LIST)))`,
which has a trailing slash. This patch removes the slashes added when
concatenating those paths with filenames.

This patch depends on floodlight/indigo#218.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=304121