### PR TITLE
Added optional rotate_log file support in AIM log handler

### DIFF
--- a/modules/AIM/module/inc/AIM/aim_log_handler.h
+++ b/modules/AIM/module/inc/AIM/aim_log_handler.h
@@ -53,6 +53,9 @@ typedef struct aim_log_handler_config_s {
     /** Name of debug log file, optionally with full or relative path */
     char* debug_log_name;
 
+    /** Name of rotate log file, optionally with full or relative path */
+    char* rotate_log_name;
+
     /** Maximum number of bytes beyond which the debug log will be rotated */
     uint32_t max_debug_log_size;
 
@@ -113,6 +116,7 @@ void aim_log_handler_logf(void* cookie, aim_log_flag_t flag, const char* str);
  * @brief Basic initialization for console and daemonized clients.
  * @param ident The syslog ident to use (optional)
  * @param debug_log_file  The name of the debug log file (optional)
+ * @param rotate_log_file  The name of the rotate log file (optional)
  * @param max_debug_size   Maximum debug log size.
  * @param max_debug_count  Maximum number of rotated debug logs.
  *
@@ -121,6 +125,7 @@ void aim_log_handler_logf(void* cookie, aim_log_flag_t flag, const char* str);
  */
 int aim_log_handler_basic_init_all(const char* ident,
                                    const char* debug_log_file,
+                                   const char* rotate_log_file,
                                    int max_debug_log_size,
                                    int max_debug_logs);
 

--- a/modules/AIM/module/src/aim_log_handler.c
+++ b/modules/AIM/module/src/aim_log_handler.c
@@ -104,23 +104,26 @@ rotate_debug_log__(aim_log_handler_t handler)
     if (stat(handler->config.debug_log_name, &fp_log_stat) != -1) {
         if (fp_log_stat.st_size >= handler->config.max_debug_log_size) {
 
-            int debug_log_name_len = strlen(handler->config.debug_log_name);
-            char* src = aim_malloc(debug_log_name_len + 16);
-            char* dst = aim_malloc(debug_log_name_len + 16);
+            int rotate_log_name_len = strlen(handler->config.rotate_log_name);
+            char* src = aim_malloc(rotate_log_name_len + 16);
+            char* dst = aim_malloc(rotate_log_name_len + 16);
 
             int i;
 
             /* move older logs first */
             for (i = handler->config.max_debug_logs-1; i >= 1; i--) {
-                sprintf(src, "%s.%d", handler->config.debug_log_name, i);
-                sprintf(dst, "%s.%d", handler->config.debug_log_name, i+1);
+                sprintf(src, "%s.%d", handler->config.rotate_log_name, i);
+                sprintf(dst, "%s.%d", handler->config.rotate_log_name, i+1);
                 rename(src, dst);
             }
 
             /* close log, move it to .1, and open a new file */
-            sprintf(dst, "%s.1", handler->config.debug_log_name);
+            sprintf(dst, "%s.1", handler->config.rotate_log_name);
             fclose(handler->debug_fp);
-            rename(handler->config.debug_log_name, dst);
+
+            char move_files[255];
+            sprintf(move_files, "mv -f %s %s", handler->config.debug_log_name, dst);
+            system(move_files);
             handler->debug_fp = fopen(handler->config.debug_log_name, "a");
 
             aim_free(src);
@@ -234,9 +237,10 @@ static aim_log_handler_t basic_handler__ = NULL;
 
 int
 aim_log_handler_basic_init_all(const char* ident,
-                           const char* debug_log,
-                           int max_debug_log_size,
-                           int max_debug_logs)
+                               const char* debug_log,
+                               const char* rotate_log,
+                               int max_debug_log_size,
+                               int max_debug_logs)
 {
     aim_log_handler_config_t config;
     AIM_MEMSET(&config, 0, sizeof(config));
@@ -256,8 +260,15 @@ aim_log_handler_basic_init_all(const char* ident,
         /** Log to debug log file */
         config.flags |= AIM_LOG_HANDLER_FLAG_TO_DBGLOG;
         config.debug_log_name = aim_strdup(debug_log);
+        /* Initialize rotate_log_name as debug_log */
+        config.rotate_log_name = aim_strdup(debug_log);
         config.max_debug_log_size = max_debug_log_size;
         config.max_debug_logs = max_debug_logs;
+    }
+
+    /* If rotate_log is given then update it */
+    if(rotate_log) {
+        config.rotate_log_name = aim_strdup(rotate_log);
     }
 
     basic_handler__ = aim_log_handler_create(&config);


### PR DESCRIPTION
Reviewer: @poolakiran @wilmo119 

This change is to support the optional rotate_log_name file when AIM log is initialized. If rotate_log is NULL, the rotation happens using the debug_log_name.